### PR TITLE
[FEAT] 지출 생성/수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/project/planb/controller/BudgetController.java
+++ b/src/main/java/com/project/planb/controller/BudgetController.java
@@ -29,7 +29,7 @@ public class BudgetController {
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Member member = principalDetails.getMember(); // Member 객체
-        log.error("예산 생성 memberId: {}", member.getId());
+        log.info("예산 생성 memberId: {}", member.getId());
 
         BudgetResDto budgetResDto = budgetService.createBudget(budgetCreateReqDto, member);
         return ResponseEntity.ok(budgetResDto);

--- a/src/main/java/com/project/planb/controller/SpendController.java
+++ b/src/main/java/com/project/planb/controller/SpendController.java
@@ -1,6 +1,6 @@
 package com.project.planb.controller;
 
-import com.project.planb.dto.req.SpendCreateReqDto;
+import com.project.planb.dto.req.SpendReqDto;
 import com.project.planb.entity.Member;
 import com.project.planb.security.PrincipalDetails;
 import com.project.planb.service.SpendService;
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -25,12 +22,42 @@ public class SpendController {
 
     // 지출 등록
     @PostMapping
-    public ResponseEntity<SpendCreateReqDto> createSpend(
-            @RequestBody @Valid SpendCreateReqDto spendCreateReqDto,
+    public ResponseEntity<SpendReqDto> createSpend(
+            @RequestBody @Valid SpendReqDto spendReqDto,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Member member = principalDetails.getMember();
-        SpendCreateReqDto createdSpend = spendService.createSpend(spendCreateReqDto, member);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdSpend); // 201, 응답 dto 따로 생성 안 하고 확인
+
+        log.info("지출 생성 memberId: {}", member.getId());
+
+        SpendReqDto createdSpend = spendService.createSpend(spendReqDto, member);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdSpend);
+
+        /* todo : 201, 응답 dto 따로 생성 안 하고 확인 확인 할 정보는 log로 찍어보기, 차이점 정리할 것 */
     }
+
+    /*
+    지출 조회는 `기간별 조회가 베이스이다.` | 기간을 선택 안 했을 때 전체 조회도 고려 => 프론트단 생각해보기
+    조회된 모든 기간의 지출 합계와 카테고리 별 지출 합계를 같이 반환
+    특정 카테고리만으로도 조회할 수 있다
+    최소, 최대 금액으로 조회
+    합계제외 처리한 지출은 목록에 포함되지만, 모든 지출 합계에서는 제외처리
+    */
+
+    // 지출 수정
+    @PatchMapping("/{spendId}")
+    public ResponseEntity<SpendReqDto> updateSpend(
+            @PathVariable("spendId") Long spendId,
+            @RequestBody @Valid SpendReqDto spendReqDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+
+        log.info("지출 수정 memberId: {}, spendId: {}", member.getId(), spendId);
+
+        SpendReqDto updatedSpend = spendService.updateSpend(spendId, spendReqDto, member);
+        return ResponseEntity.ok(updatedSpend);
+    }
+
+    // 지출 삭제
 }

--- a/src/main/java/com/project/planb/controller/SpendController.java
+++ b/src/main/java/com/project/planb/controller/SpendController.java
@@ -1,0 +1,36 @@
+package com.project.planb.controller;
+
+import com.project.planb.dto.req.SpendCreateReqDto;
+import com.project.planb.entity.Member;
+import com.project.planb.security.PrincipalDetails;
+import com.project.planb.service.SpendService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/spends")
+@RequiredArgsConstructor
+public class SpendController {
+
+    private final SpendService spendService;
+
+    // 지출 등록
+    @PostMapping
+    public ResponseEntity<SpendCreateReqDto> createSpend(
+            @RequestBody @Valid SpendCreateReqDto spendCreateReqDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+        SpendCreateReqDto createdSpend = spendService.createSpend(spendCreateReqDto, member);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdSpend); // 201, 응답 dto 따로 생성 안 하고 확인
+    }
+}

--- a/src/main/java/com/project/planb/controller/SpendController.java
+++ b/src/main/java/com/project/planb/controller/SpendController.java
@@ -60,4 +60,16 @@ public class SpendController {
     }
 
     // 지출 삭제
+    @DeleteMapping("/{spendId}")
+    public ResponseEntity<Void> deleteSpend(
+            @PathVariable("spendId") Long spendId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+
+        log.info("지출 삭제 memberId: {}, spendId: {}", member.getId(), spendId);
+
+        spendService.deleteSpend(spendId, member);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/project/planb/dto/req/SpendCreateReqDto.java
+++ b/src/main/java/com/project/planb/dto/req/SpendCreateReqDto.java
@@ -1,0 +1,37 @@
+package com.project.planb.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.planb.entity.Category;
+import com.project.planb.entity.Member;
+import com.project.planb.entity.Spend;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+public record SpendCreateReqDto(
+
+        @NotNull(message = "카테고리를 선택해주세요")
+        Long categoryId,
+
+        @NotNull(message = "금액은 필수 입력 사항입니다.")
+        @Min(value = 0, message = "0 이상이어야 합니다.")
+        Integer amount,
+
+        String memo,
+
+        @NotNull(message = "날짜는 필수 입력 사항입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate spendAt,
+
+        Boolean isExcludedSum // null일 경우 false
+) {
+    public Spend toEntity(Member member, Category category) {
+        return Spend.builder()
+                .member(member)
+                .spendAt(spendAt)
+                .category(category)
+                .amount(amount)
+                .memo(memo)
+                .isExcludedSum(isExcludedSum != null ? isExcludedSum : false)
+                .build();
+    }
+}

--- a/src/main/java/com/project/planb/dto/req/SpendReqDto.java
+++ b/src/main/java/com/project/planb/dto/req/SpendReqDto.java
@@ -7,7 +7,7 @@ import com.project.planb.entity.Spend;
 import jakarta.validation.constraints.*;
 import java.time.LocalDate;
 
-public record SpendCreateReqDto(
+public record SpendReqDto(
 
         @NotNull(message = "카테고리를 선택해주세요")
         Long categoryId,

--- a/src/main/java/com/project/planb/entity/Budget.java
+++ b/src/main/java/com/project/planb/entity/Budget.java
@@ -24,7 +24,6 @@ public class Budget {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    // 예산 총액
     @Column(name = "budget_amount", nullable = false)
     private Integer amount;
 
@@ -39,11 +38,7 @@ public class Budget {
         this.member = member;
         this.category = category;
         this.amount = amount != null ? amount : 0;
-        this.year = year; // 년 설정
-        this.month = month; // 월 설정
-    }
-
-    public void updateAmount(Integer amount) {
-        this.amount = amount;
+        this.year = year;
+        this.month = month;
     }
 }

--- a/src/main/java/com/project/planb/entity/Category.java
+++ b/src/main/java/com/project/planb/entity/Category.java
@@ -19,23 +19,13 @@ public class Category {
     @Column(nullable = false, unique = true)
     private String categoryName;
 
-    @Column(nullable = false)
-    Integer averageRate;
-
     @Builder
-    public Category(String categoryName, Integer averageRate){
+    public Category(String categoryName){
         this.categoryName = categoryName;
-        this.averageRate = averageRate != null ? averageRate : 0;
     }
 
-    public Category(Long id, String categoryName, Integer averageRate) {
+    public Category(Long id, String categoryName) {
         this.id = id;
         this.categoryName = categoryName;
-        this.averageRate = averageRate != null ? averageRate : 0;
-    }
-
-    // 예산 카테고리 평균값 업데이트
-    public void updateAverageRate(Integer averageRate){
-        this.averageRate = averageRate;
     }
 }

--- a/src/main/java/com/project/planb/entity/Spend.java
+++ b/src/main/java/com/project/planb/entity/Spend.java
@@ -1,0 +1,51 @@
+package com.project.planb.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Spend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "spend_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 일자만 필요하므로 LocalDate
+    @Column
+    private LocalDate spendAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(name = "spend_amount", nullable = false)
+    private Integer amount;
+
+    private String memo;
+
+    // 합계 제외
+    @Column(nullable = false)
+    private Boolean isExcludedSum;
+
+    @Builder
+    public Spend(Member member, LocalDate spendAt, Category category, Integer amount, String memo, Boolean isExcludedSum){
+        this.member = member;
+        this.spendAt = spendAt;
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.isExcludedSum = isExcludedSum != null ? isExcludedSum : false;  // 기본값 false(제외하지 않음)
+    }
+}

--- a/src/main/java/com/project/planb/entity/Spend.java
+++ b/src/main/java/com/project/planb/entity/Spend.java
@@ -48,4 +48,13 @@ public class Spend {
         this.memo = memo;
         this.isExcludedSum = isExcludedSum != null ? isExcludedSum : false;  // 기본값 false(제외하지 않음)
     }
+
+    // 수정 메서드
+    public void spendUpdate(LocalDate spendAt, Category category, Integer amount, String memo, Boolean isExcludedSum) {
+        this.spendAt = spendAt;
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.isExcludedSum = isExcludedSum != null ? isExcludedSum : false;  // 기본값 false(제외하지 않음)
+    }
 }

--- a/src/main/java/com/project/planb/exception/ErrorCode.java
+++ b/src/main/java/com/project/planb/exception/ErrorCode.java
@@ -28,7 +28,11 @@ public enum ErrorCode {
 
     /* Category Exception */
     // 404 error
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+
+    /* Spend Exception */
+    SPEND_NOT_FOUND(HttpStatus.NOT_FOUND, "지출 정보가 존재하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/project/planb/repository/SpendRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendRepository.java
@@ -1,0 +1,13 @@
+package com.project.planb.repository;
+
+import com.project.planb.entity.Member;
+import com.project.planb.entity.Spend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpendRepository extends JpaRepository<Spend, Long> {
+
+    // 지출 생성 조회
+    List<Spend> findByMember(Member member);
+}

--- a/src/main/java/com/project/planb/service/BudgetService.java
+++ b/src/main/java/com/project/planb/service/BudgetService.java
@@ -9,6 +9,7 @@ import com.project.planb.exception.CustomException;
 import com.project.planb.exception.ErrorCode;
 import com.project.planb.repository.BudgetRepository;
 import com.project.planb.repository.CategoryRepository;
+import com.project.planb.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ public class BudgetService {
 
     private final CategoryRepository categoryRepository;
     private final BudgetRepository budgetRepository;
+    private final MemberRepository memberRepository;
 
     // 예산 생성
     @Transactional
@@ -37,9 +39,6 @@ public class BudgetService {
                 .build();
 
         budgetRepository.save(budget);
-
-        // 평균 갱신 메서드 호출
-        updateAverageRate(category);
 
         return new BudgetResDto(
                 budget.getId(),
@@ -62,17 +61,5 @@ public class BudgetService {
                         budget.getAmount()
                 ))
                 .toList(); // toList (java 16이상)
-    }
-
-    // 카테고리별 예산 평균 메서드
-    private void updateAverageRate(Category category) {
-        List<Budget> budgets = budgetRepository.findByCategory(category);
-        double average = budgets.stream()
-                .mapToInt(Budget::getAmount)
-                .average()
-                .orElse(0);
-
-        category.updateAverageRate((int) average);
-        categoryRepository.save(category); // 카테고리에 저장
     }
 }

--- a/src/main/java/com/project/planb/service/CategoryService.java
+++ b/src/main/java/com/project/planb/service/CategoryService.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -1,6 +1,6 @@
 package com.project.planb.service;
 
-import com.project.planb.dto.req.SpendCreateReqDto;
+import com.project.planb.dto.req.SpendReqDto;
 import com.project.planb.entity.Category;
 import com.project.planb.entity.Member;
 import com.project.planb.entity.Spend;
@@ -25,17 +25,46 @@ public class SpendService {
 
     // 지출 생성
     @Transactional
-    public SpendCreateReqDto createSpend(SpendCreateReqDto spendCreateReqDto, Member member) {
+    public SpendReqDto createSpend(SpendReqDto spendReqDto, Member member) {
 
-        Category category = categoryRepository.findById(spendCreateReqDto.categoryId())
+        Category category = categoryRepository.findById(spendReqDto.categoryId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
 
         // Spend 엔티티 생성 toEntity
-        Spend spend = spendCreateReqDto.toEntity(member, category);
+        Spend spend = spendReqDto.toEntity(member, category);
 
         spendRepository.save(spend);
 
-        return new SpendCreateReqDto(
+        return new SpendReqDto(
+                category.getId(),
+                spend.getAmount(),
+                spend.getMemo(),
+                spend.getSpendAt(),
+                spend.getIsExcludedSum()
+        );
+    }
+
+    // 지출 수정
+    @Transactional
+    public SpendReqDto updateSpend(Long spendId, SpendReqDto spendReqDto, Member member) {
+        Spend spend = spendRepository.findById(spendId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SPEND_NOT_FOUND));
+
+        // memberId를 가져와 작성자 예외처리
+        // (!spend.getMember().equals(member))일 때는 제대로 구현되지 않았음
+        if (!spend.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        Category category = categoryRepository.findById(spendReqDto.categoryId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        spend.spendUpdate(spendReqDto.spendAt(), category, spendReqDto.amount(),
+                spendReqDto.memo(), spendReqDto.isExcludedSum());
+
+        spendRepository.save(spend);
+
+        return new SpendReqDto(
                 category.getId(),
                 spend.getAmount(),
                 spend.getMemo(),

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -73,6 +73,19 @@ public class SpendService {
         );
     }
 
+    // 지출 삭제
+    @Transactional
+    public void deleteSpend(Long spendId, Member member) {
+        Spend spend = spendRepository.findById(spendId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SPEND_NOT_FOUND));
+
+        if (!spend.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        spendRepository.delete(spend);
+    }
+
     // 리스트 조회 todo: 요구사항 별 추가할 것
     public List<Spend> getSpendsByMember(Member member) {
         return spendRepository.findByMember(member);

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -1,0 +1,51 @@
+package com.project.planb.service;
+
+import com.project.planb.dto.req.SpendCreateReqDto;
+import com.project.planb.entity.Category;
+import com.project.planb.entity.Member;
+import com.project.planb.entity.Spend;
+import com.project.planb.exception.CustomException;
+import com.project.planb.exception.ErrorCode;
+import com.project.planb.repository.CategoryRepository;
+import com.project.planb.repository.SpendRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpendService {
+
+    private final SpendRepository spendRepository;
+    private final CategoryRepository categoryRepository;
+
+    // 지출 생성
+    @Transactional
+    public SpendCreateReqDto createSpend(SpendCreateReqDto spendCreateReqDto, Member member) {
+
+        Category category = categoryRepository.findById(spendCreateReqDto.categoryId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        // Spend 엔티티 생성 toEntity
+        Spend spend = spendCreateReqDto.toEntity(member, category);
+
+        spendRepository.save(spend);
+
+        return new SpendCreateReqDto(
+                category.getId(),
+                spend.getAmount(),
+                spend.getMemo(),
+                spend.getSpendAt(),
+                spend.getIsExcludedSum()
+        );
+    }
+
+    // 리스트 조회 todo: 요구사항 별 추가할 것
+    public List<Spend> getSpendsByMember(Member member) {
+        return spendRepository.findByMember(member);
+    }
+}

--- a/src/test/java/com/project/planb/service/CategoryServiceTest.java
+++ b/src/test/java/com/project/planb/service/CategoryServiceTest.java
@@ -30,8 +30,8 @@ public class CategoryServiceTest {
     @DisplayName("카테고리 목록 조회 테스트")
     @Test
     void getAllCategories() {
-        Category category1 = new Category(1L, "Food",0);
-        Category category2 = new Category(2L, "Transport",0);
+        Category category1 = new Category(1L, "Food");
+        Category category2 = new Category(2L, "Transport");
 
         // order ASC 해줬기때문에 순서 바뀌면 fail (success)
         when(categoryRepository.findAllByOrderByIdAsc()).thenReturn(Arrays.asList(category1, category2));


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #16 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 예산 엔티티 및 코드 설계 수정
- 사용하지 않는 코드 삭제
- 지출 CRUD API중 `생성, 수정, 삭제` 우선 개발
- 자바 record + toEntity 활용

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- ### 생성
![스크린샷 2024-09-23 234117](https://github.com/user-attachments/assets/c00d7a7a-a607-4bb8-aa67-6057f1c96ee8)

- ### 수정
![스크린샷 2024-09-24 000018](https://github.com/user-attachments/assets/d0dddf55-e0fe-44d6-bfde-ae20b9c020a9)

- ### 삭제
![스크린샷 2024-09-24 000822](https://github.com/user-attachments/assets/e452b557-d1ab-4ee0-ab17-e9d6f67ae08e)
![스크린샷 2024-09-24 000839](https://github.com/user-attachments/assets/46eabc45-8790-4433-821f-cf8790b6e23d)


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
