### PR TITLE
[FEAT] 지출 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### properties ###
 *.properties
+
+# QueryDSL generated 클래스
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,30 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// Querydsl 설정
+def generated = 'src/main/generated'
+
+// QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(generated) // QClass가 생성될 위치
+}
+
+// build시 사용할 sourceSet 추가 설정
+sourceSets {
+	main.java.srcDirs += generated
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/planb/config/QueryDslConfig.java
+++ b/src/main/java/com/project/planb/config/QueryDslConfig.java
@@ -1,2 +1,20 @@
-package com.project.planb.config;public class QueryDslConfig {
+package com.project.planb.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    // JPA 기반의 동적 쿼리를 작성할 수 있는 config 클래스
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/project/planb/config/QueryDslConfig.java
+++ b/src/main/java/com/project/planb/config/QueryDslConfig.java
@@ -1,0 +1,2 @@
+package com.project.planb.config;public class QueryDslConfig {
+}

--- a/src/main/java/com/project/planb/controller/SpendController.java
+++ b/src/main/java/com/project/planb/controller/SpendController.java
@@ -1,6 +1,7 @@
 package com.project.planb.controller;
 
 import com.project.planb.dto.req.SpendReqDto;
+import com.project.planb.dto.res.SpendDetailDto;
 import com.project.planb.dto.res.SpendResDto;
 import com.project.planb.entity.Member;
 import com.project.planb.exception.CustomException;
@@ -49,7 +50,7 @@ public class SpendController {
     최소, 최대 금액으로 조회
     합계제외 처리한 지출은 목록에 포함되지만, 모든 지출 합계에서는 제외처리
     */
-    // 지출 조회
+    // 지출 목록 조회
     @GetMapping
     public ResponseEntity<SpendResDto> getSpends(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
@@ -83,6 +84,17 @@ public class SpendController {
 
         SpendResDto spends = spendService.getSpends(member, startDate, endDate, categoryId, minAmount, maxAmount);
         return ResponseEntity.ok(spends);
+    }
+
+    // 지출 상세 조회
+    @GetMapping("/{spendId}")
+    public ResponseEntity<SpendDetailDto> getSpendDetail(
+            @PathVariable("spendId") Long spendId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+        SpendDetailDto spendDetail = spendService.getSpendDetail(member, spendId);
+        return ResponseEntity.ok(spendDetail);
     }
 
 

--- a/src/main/java/com/project/planb/dto/res/SpendDetailDto.java
+++ b/src/main/java/com/project/planb/dto/res/SpendDetailDto.java
@@ -1,0 +1,13 @@
+package com.project.planb.dto.res;
+
+import java.time.LocalDate;
+
+public record SpendDetailDto(
+        Long id,
+        LocalDate spendAt,
+        Long categoryId,
+        String categoryName,
+        Integer amount,
+        String memo,
+        Boolean isExcludedSum
+) {}

--- a/src/main/java/com/project/planb/dto/res/SpendResDto.java
+++ b/src/main/java/com/project/planb/dto/res/SpendResDto.java
@@ -1,2 +1,21 @@
-package com.project.planb.dto.res;public class SpendResDto {
+package com.project.planb.dto.res;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record SpendResDto(
+        Integer totalAmount, // 총 지출액
+        Map<Long, Integer> categoryAmounts, // 카테고리별 지출 총액
+        List<SpendList> spendList // 각 지출 정보
+) {
+    // 지출 정보를 위한 내부 클래스 (SpendList) = 목록 조회
+    public record SpendList(
+            Long id,
+            LocalDate spendAt,
+            Long categoryId,
+            Integer amount,
+            String memo,
+            Boolean isExcludedSum
+    ) {}
 }

--- a/src/main/java/com/project/planb/dto/res/SpendResDto.java
+++ b/src/main/java/com/project/planb/dto/res/SpendResDto.java
@@ -1,0 +1,2 @@
+package com.project.planb.dto.res;public class SpendResDto {
+}

--- a/src/main/java/com/project/planb/exception/CustomException.java
+++ b/src/main/java/com/project/planb/exception/CustomException.java
@@ -9,4 +9,9 @@ public class CustomException extends RuntimeException {
         super(e.getMessage());
         this.errorCode = e;
     }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message); // 메시지를 String으로 전달
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/project/planb/exception/ErrorCode.java
+++ b/src/main/java/com/project/planb/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
 
     /* General Exception 500 */
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류입니다."),
+
+    /* error */
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
 
     /* Member Exception */

--- a/src/main/java/com/project/planb/repository/SpendQRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendQRepository.java
@@ -5,6 +5,6 @@ import com.project.planb.entity.Spend;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface SpendRepositoryCustom {
+public interface SpendQRepository {
     List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum);
 }

--- a/src/main/java/com/project/planb/repository/SpendQRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendQRepository.java
@@ -1,0 +1,10 @@
+package com.project.planb.repository;
+
+import com.project.planb.entity.Spend;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SpendRepositoryCustom {
+    List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum);
+}

--- a/src/main/java/com/project/planb/repository/SpendRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendRepository.java
@@ -1,13 +1,7 @@
 package com.project.planb.repository;
 
-import com.project.planb.entity.Member;
 import com.project.planb.entity.Spend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface SpendRepository extends JpaRepository<Spend, Long> {
-
-    // 지출 생성 조회
-    List<Spend> findByMember(Member member);
 }

--- a/src/main/java/com/project/planb/repository/SpendRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendRepository.java
@@ -1,7 +1,11 @@
 package com.project.planb.repository;
 
+import com.project.planb.entity.Member;
 import com.project.planb.entity.Spend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SpendRepository extends JpaRepository<Spend, Long> {
+    Optional<Spend> findByIdAndMember(Long spendId, Member member);
 }

--- a/src/main/java/com/project/planb/repository/impl/SpendQRepositoryImpl.java
+++ b/src/main/java/com/project/planb/repository/impl/SpendQRepositoryImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class SpendRepositoryCustomImpl implements SpendQRepository {
+public class SpendQRepositoryImpl implements SpendQRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/project/planb/repository/impl/SpendRepositoryCustomImpl.java
+++ b/src/main/java/com/project/planb/repository/impl/SpendRepositoryCustomImpl.java
@@ -1,7 +1,9 @@
-package com.project.planb.repository;
+package com.project.planb.repository.impl;
 
 import com.project.planb.entity.QSpend;
 import com.project.planb.entity.Spend;
+import com.project.planb.repository.SpendQRepository;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,7 +13,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class SpendRepositoryCustomImpl implements SpendRepositoryCustom {
+public class SpendRepositoryCustomImpl implements SpendQRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -19,16 +21,31 @@ public class SpendRepositoryCustomImpl implements SpendRepositoryCustom {
     public List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum) {
 
         // Querydsl을 사용한 동적 쿼리 작성
+        QSpend spend = QSpend.spend; // QSpend 인스턴스 생성
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 필수 조건 = memberId, 날짜 (but 입력 안 했을 시 현재 달)
+        builder.and(spend.member.id.eq(memberId));
+        builder.and(spend.spendAt.between(startDate, endDate));
+
+        // 선택적 조건 추가
+        if (categoryId != null) {
+            builder.and(spend.category.id.eq(categoryId));
+        }
+        if (minAmount != null) {
+            builder.and(spend.amount.goe(minAmount));
+        }
+        if (maxAmount != null) {
+            builder.and(spend.amount.loe(maxAmount));
+        }
+        if (isExcludedSum != null) {
+            builder.and(spend.isExcludedSum.eq(isExcludedSum));
+        }
+
         return queryFactory
-                .selectFrom(QSpend.spend)
-                .where(
-                        QSpend.spend.member.id.eq(memberId),
-                        QSpend.spend.spendAt.between(startDate, endDate),
-                        categoryId != null ? QSpend.spend.category.id.eq(categoryId) : null,
-                        minAmount != null ? QSpend.spend.amount.goe(minAmount) : null,
-                        maxAmount != null ? QSpend.spend.amount.loe(maxAmount) : null,
-                        isExcludedSum != null ? QSpend.spend.isExcludedSum.eq(isExcludedSum) : null
-                )
+                .selectFrom(spend)
+                .where(builder)
                 .fetch();
     }
 }

--- a/src/main/java/com/project/planb/repository/impl/SpendRepositoryCustomImpl.java
+++ b/src/main/java/com/project/planb/repository/impl/SpendRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.project.planb.repository;
+
+import com.project.planb.entity.QSpend;
+import com.project.planb.entity.Spend;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SpendRepositoryCustomImpl implements SpendRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum) {
+
+        // Querydsl을 사용한 동적 쿼리 작성
+        return queryFactory
+                .selectFrom(QSpend.spend)
+                .where(
+                        QSpend.spend.member.id.eq(memberId),
+                        QSpend.spend.spendAt.between(startDate, endDate),
+                        categoryId != null ? QSpend.spend.category.id.eq(categoryId) : null,
+                        minAmount != null ? QSpend.spend.amount.goe(minAmount) : null,
+                        maxAmount != null ? QSpend.spend.amount.loe(maxAmount) : null,
+                        isExcludedSum != null ? QSpend.spend.isExcludedSum.eq(isExcludedSum) : null
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -97,8 +97,10 @@ public class SpendService {
     public SpendResDto getSpends(Member member, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount) {
         List<Spend> spends = spendQRepository.searchSpends(member.getId(), startDate, endDate, categoryId, minAmount, maxAmount, null);
 
-        // 총액 계산
-        Integer totalAmount = spends.stream().mapToInt(Spend::getAmount).sum();
+        Integer totalAmount = spends.stream()
+                .filter(spend -> !spend.getIsExcludedSum()) // 합계 제외 필터링
+                .mapToInt(Spend::getAmount)
+                .sum();
 
         // 카테고리별 지출 총액 계산
         Map<Long, Integer> categoryAmountsMap = spends.stream()

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -1,6 +1,7 @@
 package com.project.planb.service;
 
 import com.project.planb.dto.req.SpendReqDto;
+import com.project.planb.dto.res.SpendDetailDto;
 import com.project.planb.dto.res.SpendResDto;
 import com.project.planb.entity.Category;
 import com.project.planb.entity.Member;
@@ -93,7 +94,7 @@ public class SpendService {
     }
 
 
-    // 지출 조회 메서드
+    // 지출 목록 조회 메서드
     public SpendResDto getSpends(Member member, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount) {
         List<Spend> spends = spendQRepository.searchSpends(member.getId(), startDate, endDate, categoryId, minAmount, maxAmount, null);
 
@@ -120,5 +121,25 @@ public class SpendService {
                 .toList();
 
         return new SpendResDto(totalAmount, categoryAmountsMap, spendDetails);
+    }
+
+    // 지출 상세
+    public SpendDetailDto getSpendDetail(Member member, Long spendId) {
+        Spend spend = spendRepository.findByIdAndMember(spendId, member)
+                .orElseThrow(() -> new CustomException(ErrorCode.SPEND_NOT_FOUND));
+
+        if (!spend.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return new SpendDetailDto(
+                spend.getId(),
+                spend.getSpendAt(),
+                spend.getCategory().getId(),
+                spend.getCategory().getCategoryName(),
+                spend.getAmount(),
+                spend.getMemo(),
+                spend.getIsExcludedSum()
+        );
     }
 }

--- a/src/main/java/com/project/planb/service/SpendService.java
+++ b/src/main/java/com/project/planb/service/SpendService.java
@@ -1,19 +1,24 @@
 package com.project.planb.service;
 
 import com.project.planb.dto.req.SpendReqDto;
+import com.project.planb.dto.res.SpendResDto;
 import com.project.planb.entity.Category;
 import com.project.planb.entity.Member;
 import com.project.planb.entity.Spend;
 import com.project.planb.exception.CustomException;
 import com.project.planb.exception.ErrorCode;
 import com.project.planb.repository.CategoryRepository;
+import com.project.planb.repository.SpendQRepository;
 import com.project.planb.repository.SpendRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -22,6 +27,7 @@ public class SpendService {
 
     private final SpendRepository spendRepository;
     private final CategoryRepository categoryRepository;
+    private final SpendQRepository spendQRepository;
 
     // 지출 생성
     @Transactional
@@ -86,8 +92,31 @@ public class SpendService {
         spendRepository.delete(spend);
     }
 
-    // 리스트 조회 todo: 요구사항 별 추가할 것
-    public List<Spend> getSpendsByMember(Member member) {
-        return spendRepository.findByMember(member);
+
+    // 지출 조회 메서드
+    public SpendResDto getSpends(Member member, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount) {
+        List<Spend> spends = spendQRepository.searchSpends(member.getId(), startDate, endDate, categoryId, minAmount, maxAmount, null);
+
+        // 총액 계산
+        Integer totalAmount = spends.stream().mapToInt(Spend::getAmount).sum();
+
+        // 카테고리별 지출 총액 계산
+        Map<Long, Integer> categoryAmountsMap = spends.stream()
+                .collect(Collectors.groupingBy(spend -> spend.getCategory().getId(),
+                        Collectors.summingInt(Spend::getAmount)));
+
+        // SpendDetail 리스트로 변환
+        List<SpendResDto.SpendList> spendDetails = spends.stream()
+                .map(spend -> new SpendResDto.SpendList(
+                        spend.getId(),
+                        spend.getSpendAt(),
+                        spend.getCategory().getId(),
+                        spend.getAmount(),
+                        spend.getMemo(),
+                        spend.getIsExcludedSum()
+                ))
+                .toList();
+
+        return new SpendResDto(totalAmount, categoryAmountsMap, spendDetails);
     }
 }


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #19 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
queryDSL을 사용하여 동적쿼리를 효율적으로 관리하였습니다.
- `공통` = `기간` 으로 조회 => null값일 시 현재 달을 기준으로 검색
- 조회된 모든 내용의 `지출 합계` , `카테고리 별 지출 합계` 를 같이 반환
- 특정 `카테고리` 만 조회.
- `최소` , `최대` 금액으로 조회.
- `합계 제외` 처리한 지출은 목록에 포함되지만, 모든 `지출 합계`에서 제외
- 지출 상세보기 추가

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
