### PR TITLE
[FEAT] 오늘의 지출 안내 API 기능 구현

### DIFF
--- a/src/main/java/com/project/planb/PlanbApplication.java
+++ b/src/main/java/com/project/planb/PlanbApplication.java
@@ -2,8 +2,10 @@ package com.project.planb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PlanbApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/project/planb/controller/ConsultingController.java
+++ b/src/main/java/com/project/planb/controller/ConsultingController.java
@@ -1,7 +1,14 @@
 package com.project.planb.controller;
 
+import com.project.planb.dto.res.TodaySpendDto;
+import com.project.planb.entity.Member;
+import com.project.planb.security.PrincipalDetails;
+import com.project.planb.service.ConsultingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,9 +16,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/spends/today")
-public class TodaySpendController {
+public class ConsultingController {
+
+    private final ConsultingService consultingService;
 
     /*
     오늘의 지출 안내
     */
+    @GetMapping
+    public ResponseEntity<TodaySpendDto> getTodaySpend(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+
+        log.info("오늘 지출 조회 memberId: {}", member.getId());
+
+        TodaySpendDto todaySpend = consultingService.getTodaySpend(member);
+        return ResponseEntity.ok(todaySpend);
+    }
 }

--- a/src/main/java/com/project/planb/controller/ConsultingController.java
+++ b/src/main/java/com/project/planb/controller/ConsultingController.java
@@ -1,0 +1,17 @@
+package com.project.planb.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/spends/today")
+public class TodaySpendController {
+
+    /*
+    오늘의 지출 안내
+    */
+}

--- a/src/main/java/com/project/planb/controller/SpendController.java
+++ b/src/main/java/com/project/planb/controller/SpendController.java
@@ -17,7 +17,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/project/planb/dto/res/TodaySpendDto.java
+++ b/src/main/java/com/project/planb/dto/res/TodaySpendDto.java
@@ -1,0 +1,18 @@
+package com.project.planb.dto.res;
+
+import java.util.List;
+
+public record TodaySpendDto(
+        int totalSpentAmount,   // 오늘 총 지출 금액, 사용된 금액이므로 = `spent`로 설정
+        int recommendedAmount,   // 사용 적정 금액
+        double totalRisk,        // 종합 위험도
+        List<CategorySpendDto> categories   // 카테고리별 지출 정보 담을 것 List
+) {
+    // 오늘의 지출 정보를 위한 내부 클래스
+    public record CategorySpendDto(
+            String categoryName,
+            int todayRecommendedAmount, // 오늘의 적정 금액
+            int spentAmount,       // 실제 사용 금액
+            double risk            // 위험도
+    ) {}
+}

--- a/src/main/java/com/project/planb/exception/ErrorCode.java
+++ b/src/main/java/com/project/planb/exception/ErrorCode.java
@@ -33,7 +33,10 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
     /* Spend Exception */
-    SPEND_NOT_FOUND(HttpStatus.NOT_FOUND, "지출 정보가 존재하지 않습니다.");
+    SPEND_NOT_FOUND(HttpStatus.NOT_FOUND, "지출 정보가 존재하지 않습니다."),
+
+    /* Budget Exception */
+    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "예산 정보가 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/project/planb/repository/BudgetRepository.java
+++ b/src/main/java/com/project/planb/repository/BudgetRepository.java
@@ -4,14 +4,23 @@ import com.project.planb.entity.Budget;
 import com.project.planb.entity.Category;
 import com.project.planb.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     // 예산 생성 조회
     List<Budget> findByMember(Member member);
 
-    // 카테고리별 예산 조회
-    List<Budget> findByCategory(Category category);
+    // 특정 카테고리와 특정 연도/월에 대한 예산 조회 > 예산 조회는 이거 하나이므로 따로 queryDsl 파일 X
+    @Query("SELECT b FROM Budget b WHERE b.member.id = :memberId AND b.category.id = :categoryId AND b.year = :year AND b.month = :month")
+    Optional<Budget> findByMemberAndCategoryAndYearAndMonth(
+            @Param("memberId") Long memberId,
+            @Param("categoryId") Long categoryId,
+            @Param("year") int year,
+            @Param("month") int month
+    );
 }

--- a/src/main/java/com/project/planb/repository/SpendQRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendQRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface SpendQRepository {
     List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum);
+
+    // List<Spend> findTodaySpends(Long memberId, LocalDate today);
 }

--- a/src/main/java/com/project/planb/repository/SpendRepository.java
+++ b/src/main/java/com/project/planb/repository/SpendRepository.java
@@ -3,9 +3,17 @@ package com.project.planb.repository;
 import com.project.planb.entity.Member;
 import com.project.planb.entity.Spend;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface SpendRepository extends JpaRepository<Spend, Long> {
     Optional<Spend> findByIdAndMember(Long spendId, Member member);
+
+    // 오늘의 지출 - 단순 조회용이므로 queryDsl 사용 X
+    @Query("SELECT s FROM Spend s WHERE s.member = :member AND s.spendAt = :today")
+    List<Spend> findTodaySpends(@Param("member") Member member, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/project/planb/repository/impl/SpendQRepositoryImpl.java
+++ b/src/main/java/com/project/planb/repository/impl/SpendQRepositoryImpl.java
@@ -17,6 +17,7 @@ public class SpendQRepositoryImpl implements SpendQRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    // 지출 목록 조회
     @Override
     public List<Spend> searchSpends(Long memberId, LocalDate startDate, LocalDate endDate, Long categoryId, Integer minAmount, Integer maxAmount, Boolean isExcludedSum) {
 
@@ -48,4 +49,16 @@ public class SpendQRepositoryImpl implements SpendQRepository {
                 .where(builder)
                 .fetch();
     }
+
+/* 오늘의 지출 안내
+    @Override
+    public List<Spend> findTodaySpends(Long memberId, LocalDate today) {
+        QSpend spend = QSpend.spend;
+        return queryFactory
+                .selectFrom(spend)
+                .where(spend.member.id.eq(memberId)
+                        .and(spend.spendAt.eq(today)))
+                .fetch();
+    }
+*/
 }

--- a/src/main/java/com/project/planb/service/ConsultingService.java
+++ b/src/main/java/com/project/planb/service/ConsultingService.java
@@ -1,0 +1,2 @@
+package com.project.planb.service;public class CounsultingService {
+}

--- a/src/main/java/com/project/planb/service/ConsultingService.java
+++ b/src/main/java/com/project/planb/service/ConsultingService.java
@@ -62,10 +62,10 @@ public class ConsultingService {
                             member.getId(), categoryId, today.getYear(), today.getMonthValue()
                     ).orElseThrow(() -> new CustomException(ErrorCode.BUDGET_NOT_FOUND));
 
-                    int dailyBudget = budget.getAmount() / today.lengthOfMonth();
+                    int dailyBudget = (int) Math.round((double) budget.getAmount() / today.lengthOfMonth());
 
                     // 위험도 계산
-                    double risk = (double) spentAmount / dailyBudget * 100;
+                    int risk = (int) Math.round((double) spentAmount / dailyBudget * 100); // 반올림
 
                     return new CategorySpendDto(entry.getValue().get(0).getCategory().getCategoryName(), dailyBudget, spentAmount, risk);
                 })

--- a/src/main/java/com/project/planb/service/ConsultingService.java
+++ b/src/main/java/com/project/planb/service/ConsultingService.java
@@ -1,2 +1,88 @@
-package com.project.planb.service;public class CounsultingService {
+package com.project.planb.service;
+
+import com.project.planb.dto.res.TodaySpendDto;
+import com.project.planb.dto.res.TodaySpendDto.CategorySpendDto;
+import com.project.planb.entity.Budget;
+import com.project.planb.entity.Member;
+import com.project.planb.entity.Spend;
+import com.project.planb.exception.CustomException;
+import com.project.planb.exception.ErrorCode;
+import com.project.planb.repository.BudgetRepository;
+import com.project.planb.repository.SpendRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ConsultingService {
+
+    private final SpendRepository spendRepository;
+    private final BudgetRepository budgetRepository;
+
+    public TodaySpendDto getTodaySpend(Member member) {
+        // 1. 오늘 날짜
+        LocalDate today = LocalDate.now();
+
+        log.info("today : {}", today);
+
+        // 2. 오늘의 지출 내역 가져오기 (카테고리별)
+        List<Spend> spends = spendRepository.findTodaySpends(member, today);
+
+        log.info("today spends : {}", spends);
+
+        // 3. 총 지출 금액 계산
+        int totalSpentAmount = spends.stream()
+                .mapToInt(Spend::getAmount)
+                .sum();
+
+        // 4. 카테고리별 지출 정보 및 위험도 계산
+        Map<Long, List<Spend>> categorySpendMap = spends.stream()
+                .collect(Collectors.groupingBy(spend -> spend.getCategory().getId()));
+
+        List<CategorySpendDto> categorySpendDto = categorySpendMap.entrySet()
+                .stream()
+                .map(entry -> {
+                    Long categoryId = entry.getKey();
+                    List<Spend> categorySpends = entry.getValue();
+
+                    // 해당 카테고리의 오늘 지출 금액
+                    int spentAmount = categorySpends.stream()
+                            .mapToInt(Spend::getAmount)
+                            .sum();
+
+                    // 해당 월의 예산(카테고리) 하루 예산 계산 로직 = 총액 / 일수(lengthOfMonth)
+                    Budget budget = budgetRepository.findByMemberAndCategoryAndYearAndMonth(
+                            member.getId(), categoryId, today.getYear(), today.getMonthValue()
+                    ).orElseThrow(() -> new CustomException(ErrorCode.BUDGET_NOT_FOUND));
+
+                    int dailyBudget = budget.getAmount() / today.lengthOfMonth();
+
+                    // 위험도 계산
+                    double risk = (double) spentAmount / dailyBudget * 100;
+
+                    return new CategorySpendDto(entry.getValue().get(0).getCategory().getCategoryName(), dailyBudget, spentAmount, risk);
+                })
+                .collect(Collectors.toList());
+
+        // 5. 사용 추천 금액(total)
+        int recommendedAmount = categorySpendDto.stream()
+                .mapToInt(CategorySpendDto::todayRecommendedAmount)
+                .sum();
+
+        // 6. total 위험도는 모든 카테고리의 위험도를 평균값으로 구한다
+        double totalRisk = categorySpendDto.stream()
+                .mapToDouble(CategorySpendDto::risk)
+                .average()
+                .orElse(0);
+
+        // 응답값
+        return new TodaySpendDto(totalSpentAmount, recommendedAmount, totalRisk, categorySpendDto);
+    }
 }

--- a/src/main/java/com/project/planb/utils/NotificationUtils.java
+++ b/src/main/java/com/project/planb/utils/NotificationUtils.java
@@ -1,0 +1,2 @@
+package com.project.planb.utils;public class NotificationUtils {
+}

--- a/src/main/java/com/project/planb/utils/NotificationUtils.java
+++ b/src/main/java/com/project/planb/utils/NotificationUtils.java
@@ -1,2 +1,26 @@
-package com.project.planb.utils;public class NotificationUtils {
+package com.project.planb.utils;
+
+import com.project.planb.dto.res.TodaySpendDto;
+import com.project.planb.entity.Member;
+
+import java.util.stream.Collectors;
+
+public class NotificationUtils {
+
+    /*
+    알림 발송 메세지
+     */
+
+    public static String createNotificationMessage(Member member, TodaySpendDto todaySpend) {
+        return String.format(
+                "\n안녕하세요, %s님! 오늘의 지출 정보입니다:\n총 지출: %d원\n추천 지출: %d원\n위험도: %.2f%%\n카테고리별 지출: %s",
+                member.getAccount(),
+                todaySpend.totalSpentAmount(),
+                todaySpend.recommendedAmount(),
+                todaySpend.totalRisk(),
+                todaySpend.categories().stream()
+                        .map(dto -> String.format("%s: %d원 (위험도: %.2f%%)", dto.categoryName(), dto.spentAmount(), dto.risk()))
+                        .collect(Collectors.joining(", "))
+        );
+    }
 }


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #17 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 오늘 지출한 내용을 `총액`과 `카테고리 별` 금액으로 알려줍니다.
- `일자 기준` 오늘 적정 금액 : 오늘 기준 사용했으면 적절했을 금액
(계산식 = **카테고리 별 설정한 총 예산 / today.lengthOfMonth());**)
- `일자 기준` 오늘 지출 금액 : 오늘 기준 사용한 금액

- 위험도 : 카테고리 별 적정 금액, 지출 금액의 차이를 위험도로 나타내며 %(퍼센테이지)
ex) 오늘 사용하면 적당한 금액 10,000원/ 사용한 금액 20,000원 이면 200%
(계산식 = **지출 금액 / 사용 적정 금액 * 100**)

`모든 값은 명시적 형변환을 사용하여 반올림 계산하였습니다.`

- 스케줄러 사용으로 매일 20:00 시 알림 발송
- utils 패키지 생성 => 알림 발송 형식 지정

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![스크린샷 2024-09-25 010442](https://github.com/user-attachments/assets/54b9d34c-d6ff-4740-83d3-13a137707d5a)


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
