### PR TITLE
[REFACTOR] 예산 관련 API 리팩토링

### DIFF
--- a/src/main/java/com/project/planb/controller/BudgetController.java
+++ b/src/main/java/com/project/planb/controller/BudgetController.java
@@ -1,6 +1,8 @@
 package com.project.planb.controller;
 
 import com.project.planb.dto.req.BudgetCreateReqDto;
+import com.project.planb.dto.req.BudgetFilterReqDto;
+import com.project.planb.dto.res.BudgetCreateResDto;
 import com.project.planb.dto.res.BudgetResDto;
 import com.project.planb.entity.Member;
 import com.project.planb.security.PrincipalDetails;
@@ -28,18 +30,18 @@ public class BudgetController {
     // 예산 등록 year & month
     @Operation(summary = "년/월을 지정하여 카테고리별 예산 등록")
     @PostMapping
-    public ResponseEntity<BudgetResDto> createBudget(
+    public ResponseEntity<BudgetCreateResDto> createBudget(
             @RequestBody @Valid BudgetCreateReqDto budgetCreateReqDto,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        Member member = principalDetails.getMember(); // Member 객체
+        Member member = principalDetails.getMember();
         log.info("예산 생성 memberId: {}", member.getId());
 
-        BudgetResDto budgetResDto = budgetService.createBudget(budgetCreateReqDto, member);
-        return ResponseEntity.ok(budgetResDto);
+        BudgetCreateResDto budgetCreateResDto = budgetService.createBudget(budgetCreateReqDto, member);
+        return ResponseEntity.ok(budgetCreateResDto);
     }
 
-    // 등록한 예산 리스트 조회
+    /* 등록한 예산 리스트 조회
     @Operation(summary = "사용자가 등록한 예산 리스트 조회")
     @GetMapping
     public ResponseEntity<List<BudgetResDto>> getBudgets(
@@ -49,5 +51,22 @@ public class BudgetController {
 
         List<BudgetResDto> budgets = budgetService.getBudgetsByMember(member);
         return ResponseEntity.ok(budgets);
+    }
+     */
+
+    // 등록한 예산 리스트 조회 (년/월 필터링)
+    @Operation(summary = "사용자가 등록한 예산 리스트 조회")
+    @GetMapping
+    public ResponseEntity<BudgetResDto> getBudgets(
+            @RequestParam(value = "year", required = false) Integer year,
+            @RequestParam(value = "month", required = false) Integer month,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+        log.info("예산 조회 요청 memberId: {}, year: {}, month: {}", member.getId(), year, month);
+
+        BudgetFilterReqDto filterReqDto = new BudgetFilterReqDto(year, month);
+        BudgetResDto budgetResponse = budgetService.getBudgetsByMemberAndDate(member, filterReqDto);
+        return ResponseEntity.ok(budgetResponse);
     }
 }

--- a/src/main/java/com/project/planb/dto/req/BudgetCreateReqDto.java
+++ b/src/main/java/com/project/planb/dto/req/BudgetCreateReqDto.java
@@ -2,6 +2,7 @@ package com.project.planb.dto.req;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
 
 public record BudgetCreateReqDto(
         @NotNull(message = "카테고리를 지정해주세요")
@@ -12,6 +13,7 @@ public record BudgetCreateReqDto(
         @NotNull(message = "연도를 입력해주세요")
         int year,
         @NotNull(message = "달을 입력해주세요")
+        @Range(min = 1, max = 12, message = "달은 1에서 12 사이의 값이어야 합니다.")
         int month
 ){
 }

--- a/src/main/java/com/project/planb/dto/req/BudgetFilterReqDto.java
+++ b/src/main/java/com/project/planb/dto/req/BudgetFilterReqDto.java
@@ -1,0 +1,2 @@
+package com.project.planb.dto.req;public class BudgetFilterReqDto {
+}

--- a/src/main/java/com/project/planb/dto/req/BudgetFilterReqDto.java
+++ b/src/main/java/com/project/planb/dto/req/BudgetFilterReqDto.java
@@ -1,2 +1,15 @@
-package com.project.planb.dto.req;public class BudgetFilterReqDto {
+package com.project.planb.dto.req;
+
+import org.hibernate.validator.constraints.Range;
+
+public record BudgetFilterReqDto(
+
+        /**
+         * 년 - 월로 설정 예산 조회
+         */
+        Integer year,
+
+        @Range(min = 1, max = 12, message = "1~12월 내로 입력해주세요")
+        Integer month
+) {
 }

--- a/src/main/java/com/project/planb/dto/res/BudgetCreateResDto.java
+++ b/src/main/java/com/project/planb/dto/res/BudgetCreateResDto.java
@@ -1,0 +1,2 @@
+package com.project.planb.dto.res;public class BudgetCreateResDto {
+}

--- a/src/main/java/com/project/planb/dto/res/BudgetCreateResDto.java
+++ b/src/main/java/com/project/planb/dto/res/BudgetCreateResDto.java
@@ -1,2 +1,9 @@
-package com.project.planb.dto.res;public class BudgetCreateResDto {
-}
+package com.project.planb.dto.res;
+
+public record BudgetCreateResDto(
+        Long id,
+        String categoryName,
+        int year,
+        int month,
+        Integer amount
+) {}

--- a/src/main/java/com/project/planb/dto/res/BudgetResDto.java
+++ b/src/main/java/com/project/planb/dto/res/BudgetResDto.java
@@ -1,10 +1,16 @@
 package com.project.planb.dto.res;
 
+import java.util.List;
+
 public record BudgetResDto(
-        Long id,
-        String categoryName,
-        int year,
-        int month,
-        Integer amount
+        int totalAmount,            // 총 예산
+        List<BudgetDetail> budgets  // 예산 리스트
 ) {
+    public record BudgetDetail(
+            Long id,
+            String categoryName,
+            int year,
+            int month,
+            Integer amount
+    ) {}
 }

--- a/src/main/java/com/project/planb/entity/Budget.java
+++ b/src/main/java/com/project/planb/entity/Budget.java
@@ -28,13 +28,13 @@ public class Budget {
     private Integer amount;
 
     @Column(name = "year", nullable = false)
-    private int year;
+    private Integer year;
 
     @Column(name = "month", nullable = false)
-    private int month;
+    private Integer month;
 
     @Builder
-    public Budget(Member member, Category category, Integer amount, int year, int month) {
+    public Budget(Member member, Category category, Integer amount, Integer year, Integer month) {
         this.member = member;
         this.category = category;
         this.amount = amount != null ? amount : 0;

--- a/src/main/java/com/project/planb/exception/ErrorCode.java
+++ b/src/main/java/com/project/planb/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
     SPEND_NOT_FOUND(HttpStatus.NOT_FOUND, "지출 정보가 존재하지 않습니다."),
 
     /* Budget Exception */
-    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "예산 정보가 존재하지 않습니다.");
+    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "예산 정보가 존재하지 않습니다."),
+    BUDGET_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "이번달 예산에 이미 등록된 카테고리입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/project/planb/repository/BudgetRepository.java
+++ b/src/main/java/com/project/planb/repository/BudgetRepository.java
@@ -1,7 +1,6 @@
 package com.project.planb.repository;
 
 import com.project.planb.entity.Budget;
-import com.project.planb.entity.Category;
 import com.project.planb.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,15 +11,21 @@ import java.util.Optional;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
-    // 예산 생성 조회
+    // 예산 생성 조회 (전체)
     List<Budget> findByMember(Member member);
+
+    // 예산 생성 조회 년 월
+    List<Budget> findByMemberAndYearAndMonth(Member member, Integer year, Integer month);
+
+    // 예산 년/월 중복 카테고리 생성 불가
+    boolean existsByMemberAndCategoryIdAndYearAndMonth(Member member, Long categoryId, int year, int month);
 
     // 특정 카테고리와 특정 연도/월에 대한 예산 조회 > 예산 조회는 이거 하나이므로 따로 queryDsl 파일 X
     @Query("SELECT b FROM Budget b WHERE b.member.id = :memberId AND b.category.id = :categoryId AND b.year = :year AND b.month = :month")
     Optional<Budget> findByMemberAndCategoryAndYearAndMonth(
             @Param("memberId") Long memberId,
             @Param("categoryId") Long categoryId,
-            @Param("year") int year,
-            @Param("month") int month
+            @Param("year") Integer year,
+            @Param("month") Integer month
     );
 }

--- a/src/main/java/com/project/planb/service/BudgetService.java
+++ b/src/main/java/com/project/planb/service/BudgetService.java
@@ -1,6 +1,8 @@
 package com.project.planb.service;
 
 import com.project.planb.dto.req.BudgetCreateReqDto;
+import com.project.planb.dto.req.BudgetFilterReqDto;
+import com.project.planb.dto.res.BudgetCreateResDto;
 import com.project.planb.dto.res.BudgetResDto;
 import com.project.planb.entity.Budget;
 import com.project.planb.entity.Category;
@@ -9,11 +11,11 @@ import com.project.planb.exception.CustomException;
 import com.project.planb.exception.ErrorCode;
 import com.project.planb.repository.BudgetRepository;
 import com.project.planb.repository.CategoryRepository;
-import com.project.planb.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -22,13 +24,22 @@ public class BudgetService {
 
     private final CategoryRepository categoryRepository;
     private final BudgetRepository budgetRepository;
-    private final MemberRepository memberRepository;
 
     // 예산 생성
     @Transactional
-    public BudgetResDto createBudget(BudgetCreateReqDto budgetCreateReqDto, Member member) {
+    public BudgetCreateResDto createBudget(BudgetCreateReqDto budgetCreateReqDto, Member member) {
         Category category = categoryRepository.findById(budgetCreateReqDto.categoryId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        // 중복 예외 처리: 같은 년도, 같은 달, 같은 카테고리 중복 체크
+        if (budgetRepository.existsByMemberAndCategoryIdAndYearAndMonth(
+                member,
+                category.getId(),
+                budgetCreateReqDto.year(),
+                budgetCreateReqDto.month()
+        )) {
+            throw new CustomException(ErrorCode.BUDGET_ALREADY_EXISTS);
+        }
 
         Budget budget = Budget.builder()
                 .member(member)
@@ -40,7 +51,7 @@ public class BudgetService {
 
         budgetRepository.save(budget);
 
-        return new BudgetResDto(
+        return new BudgetCreateResDto(
                 budget.getId(),
                 category.getCategoryName(),
                 budget.getYear(),
@@ -49,7 +60,7 @@ public class BudgetService {
         );
     }
 
-    // 예산 조회
+    /* 예산 조회
     public List<BudgetResDto> getBudgetsByMember(Member member) {
         List<Budget> budgets = budgetRepository.findByMember(member);
         return budgets.stream()
@@ -60,6 +71,31 @@ public class BudgetService {
                         budget.getMonth(),
                         budget.getAmount()
                 ))
-                .toList(); // toList (java 16이상)
+                .toList();
+    } */
+
+    // 년 월 예산 조회
+    public BudgetResDto getBudgetsByMemberAndDate(Member member, BudgetFilterReqDto budgetFilterReqDto) {
+        int year = (budgetFilterReqDto.year() != 0) ? budgetFilterReqDto.year() : LocalDate.now().getYear();
+        int month = (budgetFilterReqDto.month() != 0) ? budgetFilterReqDto.month() : LocalDate.now().getMonthValue();
+
+        List<Budget> budgets = budgetRepository.findByMemberAndYearAndMonth(member, year, month);
+
+        // 총 예산 계산
+        int totalAmount = budgets.stream()
+                .mapToInt(Budget::getAmount)
+                .sum();
+
+        List<BudgetResDto.BudgetDetail> budgetDetails = budgets.stream()
+                .map(budget -> new BudgetResDto.BudgetDetail(
+                        budget.getId(),
+                        budget.getCategory().getCategoryName(),
+                        budget.getYear(),
+                        budget.getMonth(),
+                        budget.getAmount()
+                ))
+                .toList();
+
+        return new BudgetResDto(totalAmount, budgetDetails);
     }
 }


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #26 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
`예산`
- 등록 리스트 전체 조회 -> 년/월 조회로 수정 (년/월을 입력하지 않았을 때 현재 년/월 예산이 조회됩니다.)
- 해당 년/월에 이미 등록한 예산 카테고리가 있으면 예외 처리
- 등록한 총 예산 값(sum) 추가

`Category Init`
- 기본 데이터 카테고리는 10가지의 적은 데이터.
List 사용하여 존재하지 않는 카테고리를 한 번에 모아 저장하던 방식에서
모든 카테고리를 한 번에 가져와 Set에 저장한 뒤 확인 후 saveAll을 통해 저장하는 방식으로 변경하여 DB 호출 최소화 시도

`Integer VS int`
- 년 / 월 객체타입 Integer 로 변경 ( 예산 조회 default : 현재 년도 현재 달 설정을 위함)
- 응답은 null이 될 일이 없으므로 int 계속 사용(메모리 사용 측면)

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![스크린샷 2024-09-27 203556](https://github.com/user-attachments/assets/8aaa759d-7770-4e5b-9238-7ed1a0beed1e)
![스크린샷 2024-09-27 203713](https://github.com/user-attachments/assets/1ff2b240-7ab3-421e-b496-0d853f25159f)


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
