### PR TITLE
[FIX] 오류 수정 및 추가구현

### DIFF
--- a/src/main/java/com/project/planb/common/utils/NotificationUtils.java
+++ b/src/main/java/com/project/planb/common/utils/NotificationUtils.java
@@ -12,15 +12,20 @@ public class NotificationUtils {
      */
 
     public static String createNotificationMessage(Member member, TodaySpendDto todaySpend) {
+        String unregisteredCategoriesMessage = todaySpend.unBudgetCategories().isEmpty() ?
+                "" :
+                "\n예산 미등록 카테고리: " + String.join(", ", todaySpend.unBudgetCategories());
+
         return String.format(
-                "\n안녕하세요, %s님! 오늘의 지출 정보입니다:\n총 지출: %d원\n추천 지출: %d원\n위험도: %.2f%%\n카테고리별 지출: %s",
+                "\n안녕하세요, %s님! 오늘의 지출 정보입니다:\n총 지출: %d원\n추천 지출: %d원\n위험도: %.2f%%\n카테고리별 지출: %s%s",
                 member.getAccount(),
                 todaySpend.totalSpentAmount(),
                 todaySpend.recommendedAmount(),
                 todaySpend.totalRisk(),
                 todaySpend.categories().stream()
                         .map(dto -> String.format("%s: %d원 (위험도: %.2f%%)", dto.categoryName(), dto.spentAmount(), dto.risk()))
-                        .collect(Collectors.joining(", "))
+                        .collect(Collectors.joining(", ")),
+                unregisteredCategoriesMessage
         );
     }
 }

--- a/src/main/java/com/project/planb/domain/budget/dto/req/BudgetCreateReqDto.java
+++ b/src/main/java/com/project/planb/domain/budget/dto/req/BudgetCreateReqDto.java
@@ -11,7 +11,7 @@ public record BudgetCreateReqDto(
         @Min(value = 0, message = "0 이상이어야 합니다.")
         Integer amount,
         @NotNull(message = "연도를 입력해주세요")
-        int year,
+        Integer year,
         @NotNull(message = "달을 입력해주세요")
         @Range(min = 1, max = 12, message = "달은 1에서 12 사이의 값이어야 합니다.")
         int month

--- a/src/main/java/com/project/planb/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/project/planb/domain/budget/service/BudgetService.java
@@ -76,8 +76,8 @@ public class BudgetService {
 
     // 년 월 예산 조회
     public BudgetResDto getBudgetsByMemberAndDate(Member member, BudgetPeriodReqDto budgetPeriodReqDto) {
-        int year = (budgetPeriodReqDto.year() != 0) ? budgetPeriodReqDto.year() : LocalDate.now().getYear();
-        int month = (budgetPeriodReqDto.month() != 0) ? budgetPeriodReqDto.month() : LocalDate.now().getMonthValue();
+        int year = (budgetPeriodReqDto.year() != null) ? budgetPeriodReqDto.year() : LocalDate.now().getYear();
+        int month = (budgetPeriodReqDto.month() != null) ? budgetPeriodReqDto.month() : LocalDate.now().getMonthValue();
 
         List<Budget> budgets = budgetRepository.findByMemberIdAndYearAndMonth(member.getId(), year, month);
 

--- a/src/main/java/com/project/planb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/planb/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.project.planb.domain.member.dto.MemberLoginReqDto;
 import com.project.planb.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class MemberController {
 
     @Operation(summary = "회원가입")
     @PostMapping("/join")
-    public ResponseEntity<String> join(@RequestBody MemberJoinReqDto reqDto) {
+    public ResponseEntity<String> join(@RequestBody @Valid MemberJoinReqDto reqDto) {
         memberService.join(reqDto);
         return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
     }

--- a/src/main/java/com/project/planb/domain/member/dto/MemberJoinReqDto.java
+++ b/src/main/java/com/project/planb/domain/member/dto/MemberJoinReqDto.java
@@ -1,7 +1,13 @@
 package com.project.planb.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record MemberJoinReqDto(
+        @NotBlank(message = "아이디를 입력해주세요")
         String account,
-        String password
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        String password,
+
+        Boolean notificationEnabled
 ) {
 }

--- a/src/main/java/com/project/planb/domain/member/entity/Member.java
+++ b/src/main/java/com/project/planb/domain/member/entity/Member.java
@@ -23,17 +23,22 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    private Boolean notificationEnabled;
+
     // 객체 생성
     @Builder
-    public Member(String account, String password){
+    public Member(String account, String password, Boolean notificationEnabled){
         this.account = account;
         this.password = password;
+        this.notificationEnabled = notificationEnabled != null ? notificationEnabled : false;
     }
 
     // 저장 & 연관 객체 메소드
-    public Member(Long id, String account, String password){
+    public Member(Long id, String account, String password, Boolean notificationEnabled){
         this.id = id;
         this.account = account;
         this.password = password;
+        this.notificationEnabled = notificationEnabled != null ? notificationEnabled : false;
     }
 }

--- a/src/main/java/com/project/planb/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/planb/domain/member/service/MemberService.java
@@ -35,6 +35,7 @@ public class MemberService {
         Member member = Member.builder()
                 .account(reqDto.account())
                 .password(passwordEncoder.encode(reqDto.password()))
+                .notificationEnabled(reqDto.notificationEnabled())
                 .build();
         memberRepository.save(member);
     }

--- a/src/main/java/com/project/planb/domain/spend/dto/res/TodaySpendDto.java
+++ b/src/main/java/com/project/planb/domain/spend/dto/res/TodaySpendDto.java
@@ -8,7 +8,8 @@ public record TodaySpendDto(
         int recommendedAmount,   // 사용 적정 금액
         double totalRisk,        // 종합 위험도
         List<CategorySpendDto> categories,   // 카테고리별 지출 정보 담을 것 List
-        Optional<String> message
+        Optional<String> message,
+        List<String> unBudgetCategories // 예산 미등록 카테고리
 ) {
     // 오늘의 지출 정보를 위한 내부 클래스
     public record CategorySpendDto(

--- a/src/main/java/com/project/planb/domain/spend/repository/SpendRepository.java
+++ b/src/main/java/com/project/planb/domain/spend/repository/SpendRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface SpendRepository extends JpaRepository<Spend, Long>, SpendQRepository {
 
     // 지출 상세
-    Optional<Spend> findByIdAndMemberId(Long spendId, Member memberId);
+    Optional<Spend> findByIdAndMemberId(Long spendId, Long memberId);
 
     // 오늘의 지출 - 단순 조회용이므로 queryDsl 사용 X
     @Query("SELECT s FROM Spend s WHERE s.member = :member AND s.spendAt = :today")

--- a/src/main/java/com/project/planb/domain/spend/service/SpendService.java
+++ b/src/main/java/com/project/planb/domain/spend/service/SpendService.java
@@ -122,7 +122,7 @@ public class SpendService {
 
     // 지출 상세
     public SpendDetailDto getSpendDetail(Member member, Long spendId) {
-        Spend spend = spendRepository.findByIdAndMemberId(spendId, member)
+        Spend spend = spendRepository.findByIdAndMemberId(spendId, member.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SPEND_NOT_FOUND));
 
         if (!spend.getMember().getId().equals(member.getId())) {

--- a/src/main/java/com/project/planb/feature/service/StatisticsService.java
+++ b/src/main/java/com/project/planb/feature/service/StatisticsService.java
@@ -111,8 +111,13 @@ public class StatisticsService {
         );
     }
 
+    /**
+     * 증감 비율 로직 = 이번주/ 이번달 신규 카테고리 지출이면 100% 표시
+     */
     private int calculateIncreaseRate(int lastValue, int currentValue) {
-        if (lastValue == 0) return 0; // 이전 값이 0일 때는 0 반환할 것
+        if (lastValue == 0) {
+            return (currentValue == 0) ? 0 : 100; // 이전 값이 0이고 현재 값이 0이 아니면 100% 증가
+        }
         return (int) (((double) (currentValue - lastValue) / lastValue) * 100); // 증가율 계산
     }
 


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #34 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 오늘의 지출 알림 on/off = member 엔티티에 boolean 컬럼 추가(기본 값 false)
- 지출 알림 시 등록하지 않은 예산 카테고리 실행 오류 수정
- 비교할 지난 지출 데이터가 없는 경우 증감비율 100%로 표시 [지출 추적이 목표이므로 설정]
- 회원가입 시 @valid 어노테이션 추가


## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
* 등록하지 않은 예산 카테고리는 위험도 0으로 표시

![스크린샷 2024-10-05 174040](https://github.com/user-attachments/assets/716abb36-3891-4149-97d1-487bbb5bebd7)


## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
