### PR TITLE
[FEAT] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/project/planb/common/config/RedisConfig.java
+++ b/src/main/java/com/project/planb/common/config/RedisConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -19,5 +21,14 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory(){
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 }

--- a/src/main/java/com/project/planb/common/config/SecurityConfig.java
+++ b/src/main/java/com/project/planb/common/config/SecurityConfig.java
@@ -32,12 +32,19 @@ public class SecurityConfig {
                                 "/swagger-ui/**",            // Swagger UI 페이지
                                 "/swagger-ui.html",          // Swagger UI HTML 페이지
                                 "/api/members/login",        // 로그인
-                                "/api/members/join",          // 회원가입
-                                "/api/members/reissue"
+                                "/api/members/join"         // 회원가입
                         ).permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터
-
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
+                // 로그아웃 설정
+                /*
+                .logout(logout -> logout
+                        .logoutUrl("/api/members/logout") // 로그아웃 요청 URL
+                        .logoutSuccessUrl("/api/members/login") // 로그아웃 성공 시 리다이렉트할 URL
+                        .invalidateHttpSession(true) // 세션 무효화
+                        .deleteCookies("") // 쿠키 삭제
+                        .permitAll());
+                */
         return http.build();
     }
 }

--- a/src/main/java/com/project/planb/common/exception/ErrorCode.java
+++ b/src/main/java/com/project/planb/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     /* Token Exception */
     // 401 error
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 
     /* Category Exception */

--- a/src/main/java/com/project/planb/common/security/dto/LogoutRequestDto.java
+++ b/src/main/java/com/project/planb/common/security/dto/LogoutRequestDto.java
@@ -1,0 +1,4 @@
+package com.project.planb.common.security.dto;
+
+public record LogoutRequestDto(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/project/planb/common/security/dto/RefreshToken.java
+++ b/src/main/java/com/project/planb/common/security/dto/RefreshToken.java
@@ -17,4 +17,5 @@ public class RefreshToken {
     private String refreshToken;
 
     private String memberId;
+    private String account;
 }

--- a/src/main/java/com/project/planb/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/planb/common/security/jwt/JwtTokenProvider.java
@@ -42,6 +42,9 @@ public class JwtTokenProvider {
     @Value("${security.jwt.prefix}")
     private String bearerPrefix;
 
+    @Value("${security.jwt.token-blacklist-TTL}")
+    private int tokenBlacklistTTL; // 블랙리스트 TTL 값 추가
+
     private final PrincipalDetailsService principalDetailsService;
 
     // 객체 생성 후 초기화 알고리즘 BASE64
@@ -106,6 +109,11 @@ public class JwtTokenProvider {
             return bearerToken.substring(bearerPrefix.length()).trim(); // "Bearer " 부분 제거
         }
         return null;
+    }
+
+    // 블랙리스트 TTL
+    public int getTokenBlacklistTTL() {
+        return tokenBlacklistTTL;
     }
 
     // 토큰 유효성 검사

--- a/src/main/java/com/project/planb/common/security/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/project/planb/common/security/repository/RefreshTokenRepository.java
@@ -3,9 +3,5 @@ package com.project.planb.common.security.repository;
 import com.project.planb.common.security.dto.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.Optional;
-
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-    // redis 객체 조회
-    Optional<RefreshToken> findByAccessToken(String accessToken);
 }

--- a/src/main/java/com/project/planb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/planb/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.project.planb.domain.member.controller;
 
+import com.project.planb.common.security.dto.LogoutRequestDto;
 import com.project.planb.common.security.dto.TokenRequestDto;
 import com.project.planb.common.security.dto.TokenResDto;
 import com.project.planb.domain.member.dto.MemberJoinReqDto;
@@ -46,5 +47,12 @@ public class MemberController {
     public ResponseEntity<TokenResDto> reissueToken(@RequestBody TokenRequestDto requestDto) {
         TokenResDto tokenResDto = memberService.reissueToken(requestDto);
         return ResponseEntity.status(HttpStatus.OK).body(tokenResDto);
+    }
+
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestBody LogoutRequestDto requestDto) {
+        memberService.logout(requestDto);
+        return ResponseEntity.ok("로그아웃이 성공적으로 완료되었습니다.");
     }
 }

--- a/src/main/java/com/project/planb/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/planb/domain/member/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getAccount());
 
         // 리프레시 토큰을 Redis에 저장
-        RefreshToken refreshTokenEntity = new RefreshToken(refreshToken, String.valueOf(member.getId()));
+        RefreshToken refreshTokenEntity = new RefreshToken(refreshToken, String.valueOf(member.getId()), member.getAccount()); // account 추가
         refreshTokenRepository.save(refreshTokenEntity);
 
         return new TokenResDto(accessToken, refreshToken);
@@ -70,7 +70,7 @@ public class MemberService {
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
 
         // 2. 저장된 리프레시 토큰이 유효하다면 새로운 액세스 토큰 생성
-        String newAccessToken = jwtTokenProvider.createAccessToken(savedToken.getMemberId());
+        String newAccessToken = jwtTokenProvider.createAccessToken(savedToken.getAccount());
 
         // 3. 새로운 액세스 토큰 반환
         return new TokenResDto(newAccessToken, savedToken.getRefreshToken());

--- a/src/main/java/com/project/planb/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/planb/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.project.planb.domain.member.service;
 
 import com.project.planb.common.exception.CustomException;
 import com.project.planb.common.exception.ErrorCode;
+import com.project.planb.common.security.dto.LogoutRequestDto;
 import com.project.planb.common.security.dto.RefreshToken;
 import com.project.planb.common.security.dto.TokenRequestDto;
 import com.project.planb.common.security.dto.TokenResDto;
@@ -12,10 +13,13 @@ import com.project.planb.domain.member.dto.MemberLoginReqDto;
 import com.project.planb.domain.member.entity.Member;
 import com.project.planb.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +29,10 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final BCryptPasswordEncoder passwordEncoder;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // 회원가입
+    @Transactional
     public void join(MemberJoinReqDto reqDto) {
         if (memberRepository.existsByAccount(reqDto.account())) {
             // 중복회원 검증
@@ -74,6 +80,25 @@ public class MemberService {
 
         // 3. 새로운 액세스 토큰 반환
         return new TokenResDto(newAccessToken, savedToken.getRefreshToken());
+    }
+
+    // 로그아웃
+    @Transactional
+    public void logout(LogoutRequestDto requestDto) {
+
+        if (!jwtTokenProvider.validateToken(requestDto.accessToken())) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        if (!jwtTokenProvider.validateToken(requestDto.refreshToken())) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Refresh Token 삭제
+        String refreshToken = requestDto.refreshToken();
+        refreshTokenRepository.deleteById(refreshToken);
+
+        // 액세스 토큰을 블랙리스트에 추가
+        redisTemplate.opsForValue().set(requestDto.accessToken(), "invalid", jwtTokenProvider.getTokenBlacklistTTL(), TimeUnit.SECONDS);
     }
 
     // account를 통해 Member 엔티티를 조회

--- a/src/main/java/com/project/planb/feature/service/ConsultingService.java
+++ b/src/main/java/com/project/planb/feature/service/ConsultingService.java
@@ -1,16 +1,14 @@
 package com.project.planb.feature.service;
 
+import com.project.planb.common.utils.NotificationUtils;
+import com.project.planb.domain.budget.entity.Budget;
+import com.project.planb.domain.budget.repository.BudgetRepository;
+import com.project.planb.domain.member.entity.Member;
+import com.project.planb.domain.member.repository.MemberRepository;
 import com.project.planb.domain.spend.dto.res.TodaySpendDto;
 import com.project.planb.domain.spend.dto.res.TodaySpendDto.CategorySpendDto;
-import com.project.planb.domain.budget.entity.Budget;
-import com.project.planb.domain.member.entity.Member;
 import com.project.planb.domain.spend.entity.Spend;
-import com.project.planb.common.exception.CustomException;
-import com.project.planb.common.exception.ErrorCode;
-import com.project.planb.domain.budget.repository.BudgetRepository;
-import com.project.planb.domain.member.repository.MemberRepository;
 import com.project.planb.domain.spend.repository.SpendRepository;
-import com.project.planb.common.utils.NotificationUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,4 @@ security:
     secret-key: ${JWT_SECRET_KEY}
     access-token-TTL: 1800 # 30분
     refresh-token-TTL: 259200
+    token-blacklist-TTL: 2700 # 45분


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #36 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- refresh 토큰을 통한 access 토큰 재발급 시 새로운 access 토큰 접근 에러 수정
[ account로 접근해서 계정 유효성을 검사하고 있었는데 memberId만 끌어오고 있어서 생긴 오류]

- 로그아웃 기능 구현
- 사용자 로그아웃 시 유효한 refreshToken은 바로 삭제 되고, accessToken은 레디스 블랙리스트를 활용해 저장해둡니다.
`accessToken 유효 시간보다 길게 설정`
- 로그아웃 시 모든 토큰이 무효화됩니다.

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
